### PR TITLE
Handle scenario when UI does not send "time_left" messages.

### DIFF
--- a/Source/TimeInfo.h
+++ b/Source/TimeInfo.h
@@ -15,6 +15,8 @@ public:
     TimeInfo(int mainTime, int byoyomiTime, int byoyomiStones) :
         _mainTime(mainTime), _byoyomiTime(byoyomiTime), _byoyomiStones(byoyomiStones)
     {
+        // Default the remaining time sensibly.
+        TimeLeft(mainTime, 0);
     }
 
     void TimeLeft(int timeLeft, int stonesLeft)


### PR DESCRIPTION
This will no longer crash OPG though time management is still not quite right in this case. Essentially OPG always thinks that it has the full game time remaining unless told otherwise!